### PR TITLE
feat(variables): ampliar compliance y metodología

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Este proyecto usa [Versionado Semántico](https://semver.org/lang/es/).
 ## [Unreleased]
 
 ### Added
+- Panel de variables: amplía los catálogos de compliance y metodología, permite selección múltiple y admite valores personalizados mediante “Otro”.
 - Panel de variables: agrega `Workspace / subproyecto`, `Estándar / compliance`, `Documentos a revisar` y `Nivel de profundidad`.
 - Panel de variables: agrega `Entrada principal`, `Objetivo específico` y `Responsable / assignee`, con migración automática de proyectos guardados.
 - Panel de variables: agrega asignaciones adicionales `TOKEN=valor` para configurar placeholders específicos sin soporte canónico.

--- a/build.py
+++ b/build.py
@@ -522,10 +522,18 @@ code {
 }
 .var-group input, .var-group select { padding: .35rem .6rem; }
 .var-group textarea { padding: .35rem .6rem; resize: vertical; min-height: 56px; }
+.var-group select[multiple] { min-height: 132px; padding: .3rem; }
+.var-group select[multiple] option { padding: .28rem .4rem; border-radius: 3px; }
 .var-group input:focus, .var-group select:focus, .var-group textarea:focus {
   border-color: #6366f1; box-shadow: 0 0 0 2px rgba(99,102,241,.15);
 }
 .var-group input::placeholder, .var-group textarea::placeholder { color: var(--tx3); }
+.var-help {
+  display: block; margin-top: .35rem; color: var(--tx3);
+  font-size: .64rem; line-height: 1.4;
+}
+.var-other-input { margin-top: .4rem; }
+.var-other-input[hidden] { display: none; }
 .var-tags { display: flex; flex-wrap: wrap; gap: .25rem; margin-top: .3rem; }
 .var-tag {
   font-size: .58rem; font-family: var(--mono); color: var(--tx3);
@@ -1421,8 +1429,80 @@ var QUICK_FIELD_VAR_MAP = {
 function syncFieldsToValues(fieldMap, values) {
   Object.keys(fieldMap).forEach(function(eid) {
     var el = document.getElementById(eid);
-    if (el) el.value = values[fieldMap[eid]] || '';
+    if (!el) return;
+    var value = values[fieldMap[eid]] || '';
+    if (!el.multiple) {
+      el.value = value;
+      return;
+    }
+    var selectedValues = value.split(',').map(function(item) { return item.trim(); }).filter(Boolean);
+    var knownValues = Array.from(el.options).map(function(option) { return option.value; });
+    var customValues = selectedValues.filter(function(item) { return knownValues.indexOf(item) < 0; });
+    Array.from(el.options).forEach(function(option) {
+      option.selected = selectedValues.indexOf(option.value) >= 0;
+    });
+    var otherOption = Array.from(el.options).find(function(option) { return option.value === '__OTHER__'; });
+    if (otherOption) otherOption.selected = customValues.length > 0;
+    el.dataset.selectedValues = JSON.stringify(
+      Array.from(el.selectedOptions).map(function(option) { return option.value; })
+    );
+    var otherInputId = el.getAttribute('data-other-input');
+    var otherInput = otherInputId ? document.getElementById(otherInputId) : null;
+    if (otherInput) {
+      otherInput.value = customValues.join(', ');
+      otherInput.hidden = customValues.length === 0;
+    }
   });
+}
+
+function readFieldValue(el) {
+  if (!el.multiple) return el.value;
+  var values = Array.from(el.selectedOptions)
+    .map(function(option) { return option.value; })
+    .filter(function(value) { return value !== '__OTHER__'; });
+  var otherInputId = el.getAttribute('data-other-input');
+  var otherInput = otherInputId ? document.getElementById(otherInputId) : null;
+  if (otherInput && !otherInput.hidden) {
+    otherInput.value.split(',').map(function(item) { return item.trim(); }).filter(Boolean)
+      .forEach(function(item) { values.push(item); });
+  }
+  return values.join(', ');
+}
+
+function syncMultiSelectOther(selectId) {
+  var select = document.getElementById(selectId);
+  if (!select) return;
+  if (selectId === 'vf-compliance') {
+    var previousValues = [];
+    try { previousValues = JSON.parse(select.dataset.selectedValues || '[]'); } catch (e) {}
+    var currentValues = Array.from(select.selectedOptions).map(function(option) { return option.value; });
+    var newlySelected = currentValues.filter(function(value) {
+      return previousValues.indexOf(value) < 0;
+    });
+    var noneOption = Array.from(select.options).find(function(option) {
+      return option.value === 'NINGUNO';
+    });
+    if (noneOption && newlySelected.indexOf('NINGUNO') >= 0) {
+      Array.from(select.options).forEach(function(option) {
+        option.selected = option.value === 'NINGUNO';
+      });
+    } else if (noneOption && newlySelected.length > 0) {
+      noneOption.selected = false;
+    }
+  }
+  select.dataset.selectedValues = JSON.stringify(
+    Array.from(select.selectedOptions).map(function(option) { return option.value; })
+  );
+  var otherInputId = select.getAttribute('data-other-input');
+  var otherInput = otherInputId ? document.getElementById(otherInputId) : null;
+  if (!otherInput) return;
+  var hasOther = Array.from(select.selectedOptions).some(function(option) {
+    return option.value === '__OTHER__';
+  });
+  otherInput.hidden = !hasOther;
+  if (!hasOther) otherInput.value = '';
+  syncProjectFromPanel();
+  updateVarsBadge();
 }
 
 function updateActiveProjectVars(fieldMap) {
@@ -1433,7 +1513,7 @@ function updateActiveProjectVars(fieldMap) {
   if (!p) return null;
   Object.keys(fieldMap).forEach(function(eid) {
     var el = document.getElementById(eid);
-    if (el) p.vars[fieldMap[eid]] = el.value;
+    if (el) p.vars[fieldMap[eid]] = readFieldValue(el);
   });
   saveProjects(list);
   return p.vars;
@@ -1901,12 +1981,6 @@ function updatePlaceholders(lang) {
     tSelect.options[9].text = lang === 'en' ? 'other' : 'otro';
     tSelect.options[9].value = lang === 'en' ? 'other' : 'otro';
   }
-  var mSelect = document.getElementById('vf-metodologia');
-  if (mSelect && mSelect.options.length > 7) {
-    mSelect.options[0].text = lang === 'en' ? '-- select --' : '-- seleccionar --';
-    mSelect.options[7].text = lang === 'en' ? 'other' : 'otro';
-    mSelect.options[7].value = lang === 'en' ? 'other' : 'otro';
-  }
   var aSelect = document.getElementById('vf-autonomia');
   if (aSelect && aSelect.options.length > 4) {
     aSelect.options[0].text = lang === 'en' ? '-- select --' : '-- seleccionar --';
@@ -1928,6 +2002,8 @@ function updatePlaceholders(lang) {
     'vf-componentes': { es: 'Lista de componentes o rutas de archivos', en: 'List of components or file paths' },
     'vf-modulo': { es: 'Nombre del módulo o funcionalidad', en: 'Module or process name' },
     'vf-stack': { es: 'ej: Python + FastAPI + PostgreSQL + Docker', en: 'e.g., Python + FastAPI + PostgreSQL + Docker' },
+    'vf-compliance-other': { es: 'Otro estándar o regulación', en: 'Other standard or regulation' },
+    'vf-metodologia-other': { es: 'Otra metodología o proceso', en: 'Other methodology or process' },
     'vf-agentes': { es: 'ej: Copilot, Claude, Codex', en: 'e.g., Copilot, Claude, Codex' },
     
     'qv-repositorio': { es: 'org/nombre-repo o URL', en: 'org/repo-name or URL' },
@@ -3123,15 +3199,31 @@ def build():
         # estándar / compliance
         '    <div class="var-group">'
         '<label for="vf-compliance"><span class="fw-lang-es">Estándar / compliance</span><span class="fw-lang-en">Standard / compliance</span></label>'
-        '<select id="vf-compliance" onchange="syncProjectFromPanel();updateVarsBadge();">'
-        '<option value="">— Seleccionar —</option>'
+        '<select id="vf-compliance" multiple data-other-input="vf-compliance-other" aria-describedby="vf-compliance-help" onchange="syncMultiSelectOther(\'vf-compliance\')">'
         '<option value="PSP">PSP</option>'
         '<option value="TSP">TSP</option>'
-        '<option value="ISO 29110">ISO 29110</option>'
+        '<option value="ISO 29110">ISO/IEC 29110</option>'
+        '<option value="ISO 9001">ISO 9001</option>'
+        '<option value="ISO 12207">ISO/IEC/IEEE 12207</option>'
+        '<option value="ISO 25010">ISO/IEC 25010</option>'
+        '<option value="ISO 27001">ISO/IEC 27001</option>'
+        '<option value="ISO 27002">ISO/IEC 27002</option>'
+        '<option value="ISO 27701">ISO/IEC 27701</option>'
+        '<option value="CMMI-DEV">CMMI-DEV</option>'
         '<option value="MOPROSOFT">MOPROSOFT</option>'
         '<option value="MAAGTICSI">MAAGTICSI</option>'
-        '<option value="NINGUNO">NINGUNO / NONE</option>'
+        '<option value="NIST CSF">NIST CSF</option>'
+        '<option value="NIST SSDF">NIST SSDF</option>'
+        '<option value="OWASP SAMM">OWASP SAMM</option>'
+        '<option value="PCI DSS">PCI DSS</option>'
+        '<option value="SOC 2">SOC 2</option>'
+        '<option value="GDPR">GDPR</option>'
+        '<option value="HIPAA">HIPAA</option>'
+        '<option value="NINGUNO">NINGUNO / NONE (exclusivo)</option>'
+        '<option value="__OTHER__">Otro / Other...</option>'
         '</select>'
+        '<small class="var-help" id="vf-compliance-help"><span class="fw-lang-es">Selecciona uno o varios con Ctrl/Cmd. “NINGUNO” es exclusivo. Usa “Otro” para valores adicionales.</span><span class="fw-lang-en">Select one or more with Ctrl/Cmd. “NONE” is exclusive. Use “Other” for additional values.</span></small>'
+        '<input id="vf-compliance-other" class="var-other-input" type="text" hidden placeholder="Otro estándar o regulación" oninput="syncProjectFromPanel();updateVarsBadge();">'
         '<div class="var-tags">'
         '<span class="var-tag"><span class="fw-lang-es">[ESTÁNDAR/COMPLIANCE]</span><span class="fw-lang-en">[STANDARD/COMPLIANCE]</span></span>'
         '</div>'
@@ -3271,17 +3363,25 @@ def build():
 
         # metodología
         '    <div class="var-group">'
-        '<label for="vf-metodologia"><span class="fw-lang-es">Metodología / branching</span><span class="fw-lang-en">Methodology / branching</span></label>'
-        '<select id="vf-metodologia" onchange="syncProjectFromPanel();updateVarsBadge();">'
-        '<option value="">-- seleccionar --</option>'
-        '<option>SCRUM</option>'
-        '<option>Kanban</option>'
-        '<option>GitHub Flow</option>'
-        '<option>GitFlow</option>'
-        '<option>Trunk-Based</option>'
-        '<option>RUP</option>'
-        '<option>otro</option>'
+        '<label for="vf-metodologia"><span class="fw-lang-es">Metodologías / proceso / branching</span><span class="fw-lang-en">Methodologies / process / branching</span></label>'
+        '<select id="vf-metodologia" multiple data-other-input="vf-metodologia-other" aria-describedby="vf-metodologia-help" onchange="syncMultiSelectOther(\'vf-metodologia\')">'
+        '<option value="Scrum">Scrum</option>'
+        '<option value="Kanban">Kanban</option>'
+        '<option value="RUP">RUP</option>'
+        '<option value="Cascada">Cascada / Waterfall</option>'
+        '<option value="Espiral">Espiral / Spiral</option>'
+        '<option value="XP">XP</option>'
+        '<option value="Lean">Lean</option>'
+        '<option value="SAFe">SAFe</option>'
+        '<option value="DevOps">DevOps</option>'
+        '<option value="DevSecOps">DevSecOps</option>'
+        '<option value="Trunk-Based Development">Trunk-Based Development</option>'
+        '<option value="GitHub Flow">GitHub Flow</option>'
+        '<option value="GitFlow">GitFlow</option>'
+        '<option value="__OTHER__">Otro / Other...</option>'
         '</select>'
+        '<small class="var-help" id="vf-metodologia-help"><span class="fw-lang-es">Permite combinar metodología, proceso y estrategia de ramas.</span><span class="fw-lang-en">Allows combining methodology, process and branching strategy.</span></small>'
+        '<input id="vf-metodologia-other" class="var-other-input" type="text" hidden placeholder="Otra metodología o proceso" oninput="syncProjectFromPanel();updateVarsBadge();">'
         '<div class="var-tags">'
         '<span class="var-tag"><span class="fw-lang-es">[METODOLOGÍA]</span><span class="fw-lang-en">[METHODOLOGY]</span></span>'
         '<span class="var-tag"><span class="fw-lang-es">[BRANCHING STRATEGY]</span><span class="fw-lang-en">[BRANCHING STRATEGY]</span></span>'

--- a/docs/requirements/BusinessRules.md
+++ b/docs/requirements/BusinessRules.md
@@ -184,14 +184,14 @@ FR-04 (Ciclo Forzado)
 | **V-07** | `modulo` | String | "notificaciones" | No |
 | **V-08** | `stack` | String | "Node.js, React, PostgreSQL" | No |
 | **V-09** | `tipo_proyecto` | Enum | "Web/API/Mobile" | No |
-| **V-10** | `metodologia` | Enum | "SCRUM/Kanban/Waterfall" | No |
+| **V-10** | `metodologia` | String[] | Scrum, RUP, DevSecOps y GitHub Flow; admite múltiples valores y opción personalizada | No |
 | **V-11** | `agentes_ia` | String[] | ["Copilot", "Claude"] | No |
 | **V-12** | `nivel_autonomia` | Enum | "alto/medio/bajo" | No |
 | **V-13** | `entrada` | Text | Requerimiento, issues, reporte o contexto principal | No |
 | **V-14** | `objetivo` | Text | Resultado específico esperado | No |
 | **V-15** | `responsable` | String | Usuario, equipo, assignee o rol | No |
 | **V-16** | `workspace` | String | Ruta del workspace o subproyecto dentro del repositorio | No |
-| **V-17** | `compliance` | String | Estándar, marco o requisito normativo aplicable | No |
+| **V-17** | `compliance` | String[] | Estándares, modelos y regulaciones aplicables; admite múltiples valores y opción personalizada | No |
 | **V-18** | `documentos` | Text | Documentos y rutas específicas que deben revisarse | No |
 | **V-19** | `profundidad` | Enum | Bajo, medio, alto, exhaustivo o forense | No |
 | **V-20** | `adicionales` | Text | Una asignación `TOKEN=valor` por línea | No |

--- a/docs/requirements/FunctionalRequirements.md
+++ b/docs/requirements/FunctionalRequirements.md
@@ -86,6 +86,7 @@ Cubre todas las funcionalidades accesibles por usuarios finales (visitantes, usu
 | **FR-VAR-05** | Aplicar sustitución de variables en tiempo real al copiar | Must | UC-07 | ✅ |
 | **FR-VAR-06** | Advertir al copiar cuando existan placeholders pendientes de captura manual | Should | UC-07 | ✅ |
 | **FR-VAR-07** | Permitir variables adicionales `TOKEN=valor` para placeholders específicos de cualquier prompt | Must | UC-04 | ✅ |
+| **FR-VAR-08** | Permitir selección múltiple y valores personalizados para compliance y metodología | Should | UC-04 | ✅ |
 
 ### 2.6 Sistema de Internacionalización (i18n)
 

--- a/index.html
+++ b/index.html
@@ -373,10 +373,18 @@ code {
 }
 .var-group input, .var-group select { padding: .35rem .6rem; }
 .var-group textarea { padding: .35rem .6rem; resize: vertical; min-height: 56px; }
+.var-group select[multiple] { min-height: 132px; padding: .3rem; }
+.var-group select[multiple] option { padding: .28rem .4rem; border-radius: 3px; }
 .var-group input:focus, .var-group select:focus, .var-group textarea:focus {
   border-color: #6366f1; box-shadow: 0 0 0 2px rgba(99,102,241,.15);
 }
 .var-group input::placeholder, .var-group textarea::placeholder { color: var(--tx3); }
+.var-help {
+  display: block; margin-top: .35rem; color: var(--tx3);
+  font-size: .64rem; line-height: 1.4;
+}
+.var-other-input { margin-top: .4rem; }
+.var-other-input[hidden] { display: none; }
 .var-tags { display: flex; flex-wrap: wrap; gap: .25rem; margin-top: .3rem; }
 .var-tag {
   font-size: .58rem; font-family: var(--mono); color: var(--tx3);
@@ -9666,7 +9674,7 @@ Use the defect analysis prompt and adapt it to:
     <div class="var-group"><label for="vf-objetivo"><span class="fw-lang-es">Objetivo puntual de salida</span><span class="fw-lang-en">Specific output objective</span></label><textarea id="vf-objetivo" placeholder="Indica el resultado concreto esperado del prompt" oninput="syncProjectFromPanel();updateVarsBadge();"></textarea><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[OBJETIVO ESPECÍFICO] reemplaza [INDICAR]</span><span class="fw-lang-en">[SPECIFIC OBJECTIVE] replaces [INDICATE]</span></span></div></div>
     <div class="var-group"><label for="vf-responsable"><span class="fw-lang-es">Responsable / assignee</span><span class="fw-lang-en">Responsible person / assignee</span></label><input id="vf-responsable" type="text" placeholder="usuario, equipo o rol" oninput="syncProjectFromPanel();updateVarsBadge();"><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[RESPONSABLE]</span><span class="fw-lang-en">[ASSIGNEE]</span></span></div></div>
     <div class="var-group"><label for="vf-workspace"><span class="fw-lang-es">Workspace / subproyecto</span><span class="fw-lang-en">Workspace / subproject</span></label><input id="vf-workspace" type="text" placeholder="apps/admin, packages/api o no aplica" oninput="syncProjectFromPanel();updateVarsBadge();"><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[WORKSPACE/SUBPROYECTO]</span><span class="fw-lang-en">[WORKSPACE/SUBPROJECT]</span></span></div></div>
-    <div class="var-group"><label for="vf-compliance"><span class="fw-lang-es">Estándar / compliance</span><span class="fw-lang-en">Standard / compliance</span></label><select id="vf-compliance" onchange="syncProjectFromPanel();updateVarsBadge();"><option value="">— Seleccionar —</option><option value="PSP">PSP</option><option value="TSP">TSP</option><option value="ISO 29110">ISO 29110</option><option value="MOPROSOFT">MOPROSOFT</option><option value="MAAGTICSI">MAAGTICSI</option><option value="NINGUNO">NINGUNO / NONE</option></select><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[ESTÁNDAR/COMPLIANCE]</span><span class="fw-lang-en">[STANDARD/COMPLIANCE]</span></span></div></div>
+    <div class="var-group"><label for="vf-compliance"><span class="fw-lang-es">Estándar / compliance</span><span class="fw-lang-en">Standard / compliance</span></label><select id="vf-compliance" multiple data-other-input="vf-compliance-other" aria-describedby="vf-compliance-help" onchange="syncMultiSelectOther('vf-compliance')"><option value="PSP">PSP</option><option value="TSP">TSP</option><option value="ISO 29110">ISO/IEC 29110</option><option value="ISO 9001">ISO 9001</option><option value="ISO 12207">ISO/IEC/IEEE 12207</option><option value="ISO 25010">ISO/IEC 25010</option><option value="ISO 27001">ISO/IEC 27001</option><option value="ISO 27002">ISO/IEC 27002</option><option value="ISO 27701">ISO/IEC 27701</option><option value="CMMI-DEV">CMMI-DEV</option><option value="MOPROSOFT">MOPROSOFT</option><option value="MAAGTICSI">MAAGTICSI</option><option value="NIST CSF">NIST CSF</option><option value="NIST SSDF">NIST SSDF</option><option value="OWASP SAMM">OWASP SAMM</option><option value="PCI DSS">PCI DSS</option><option value="SOC 2">SOC 2</option><option value="GDPR">GDPR</option><option value="HIPAA">HIPAA</option><option value="NINGUNO">NINGUNO / NONE (exclusivo)</option><option value="__OTHER__">Otro / Other...</option></select><small class="var-help" id="vf-compliance-help"><span class="fw-lang-es">Selecciona uno o varios con Ctrl/Cmd. “NINGUNO” es exclusivo. Usa “Otro” para valores adicionales.</span><span class="fw-lang-en">Select one or more with Ctrl/Cmd. “NONE” is exclusive. Use “Other” for additional values.</span></small><input id="vf-compliance-other" class="var-other-input" type="text" hidden placeholder="Otro estándar o regulación" oninput="syncProjectFromPanel();updateVarsBadge();"><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[ESTÁNDAR/COMPLIANCE]</span><span class="fw-lang-en">[STANDARD/COMPLIANCE]</span></span></div></div>
     <div class="var-group"><label for="vf-documentos"><span class="fw-lang-es">Documentos a revisar</span><span class="fw-lang-en">Documents to review</span></label><textarea id="vf-documentos" rows="3" placeholder="README.md, docs/, ADR o rutas concretas" oninput="syncProjectFromPanel();updateVarsBadge();"></textarea><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[DOCUMENTOS A REVISAR]</span><span class="fw-lang-en">[DOCUMENTS TO REVIEW]</span></span></div></div>
     <div class="var-group"><label for="vf-profundidad"><span class="fw-lang-es">Nivel de profundidad</span><span class="fw-lang-en">Depth level</span></label><select id="vf-profundidad" onchange="syncProjectFromPanel();updateVarsBadge();"><option value="">— Seleccionar —</option><option value="bajo">Bajo / Low</option><option value="medio">Medio / Medium</option><option value="alto">Alto / High</option><option value="exhaustivo">Exhaustivo / Exhaustive</option><option value="forense">Forense / Forensic</option></select><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[NIVEL DE PROFUNDIDAD] reemplaza [NIVEL]</span><span class="fw-lang-en">[DEPTH LEVEL] replaces [LEVEL]</span></span></div></div>
     <div class="var-group"><label for="vf-adicionales"><span class="fw-lang-es">Variables adicionales</span><span class="fw-lang-en">Additional variables</span></label><textarea id="vf-adicionales" rows="5" placeholder="TOKEN=valor&#10;OTRO TOKEN=otro valor" oninput="syncProjectFromPanel();updateVarsBadge();"></textarea><small style="display:block;margin-top:.35rem;color:var(--tx3);font-size:.64rem;line-height:1.4;"><span class="fw-lang-es">Una por línea. Permite completar placeholders específicos que no aparecen en los campos anteriores.</span><span class="fw-lang-en">One per line. Completes prompt-specific placeholders not covered by the fields above.</span></small></div>
@@ -9678,7 +9686,7 @@ Use the defect analysis prompt and adapt it to:
     <div style="margin:.2rem 0 .1rem;font-size:.6rem;font-weight:700;color:var(--tx3);text-transform:uppercase;letter-spacing:.1em;border-top:1px solid var(--bdr);padding-top:.65rem;">⚙ <span class="fw-lang-es">Stack &amp; Agentes IA</span><span class="fw-lang-en">Stack &amp; AI Agents</span></div>
     <div class="var-group"><label for="vf-stack"><span class="fw-lang-es">Stack tecnológico</span><span class="fw-lang-en">Tech stack</span></label><input id="vf-stack" type="text" placeholder="" oninput="syncProjectFromPanel();updateVarsBadge();"><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[STACK]</span><span class="fw-lang-en">[STACK]</span></span><span class="var-tag"><span class="fw-lang-es">[STACK TECNOLÓGICO]</span><span class="fw-lang-en">[TECH STACK]</span></span></div></div>
     <div class="var-group"><label for="vf-tipo-proyecto"><span class="fw-lang-es">Tipo de proyecto</span><span class="fw-lang-en">Project type</span></label><select id="vf-tipo-proyecto" onchange="syncProjectFromPanel();updateVarsBadge();"><option value="">-- seleccionar --</option><option>frontend SPA</option><option>API REST</option><option>full-stack</option><option>microservicio</option><option>monorepo</option><option>librería</option><option>data science</option><option>IaC</option><option>otro</option></select><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[TIPO DE PROYECTO]</span><span class="fw-lang-en">[PROJECT TYPE]</span></span><span class="var-tag"><span class="fw-lang-es">[TIPO]</span><span class="fw-lang-en">[TYPE]</span></span></div></div>
-    <div class="var-group"><label for="vf-metodologia"><span class="fw-lang-es">Metodología / branching</span><span class="fw-lang-en">Methodology / branching</span></label><select id="vf-metodologia" onchange="syncProjectFromPanel();updateVarsBadge();"><option value="">-- seleccionar --</option><option>SCRUM</option><option>Kanban</option><option>GitHub Flow</option><option>GitFlow</option><option>Trunk-Based</option><option>RUP</option><option>otro</option></select><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[METODOLOGÍA]</span><span class="fw-lang-en">[METHODOLOGY]</span></span><span class="var-tag"><span class="fw-lang-es">[BRANCHING STRATEGY]</span><span class="fw-lang-en">[BRANCHING STRATEGY]</span></span></div></div>
+    <div class="var-group"><label for="vf-metodologia"><span class="fw-lang-es">Metodologías / proceso / branching</span><span class="fw-lang-en">Methodologies / process / branching</span></label><select id="vf-metodologia" multiple data-other-input="vf-metodologia-other" aria-describedby="vf-metodologia-help" onchange="syncMultiSelectOther('vf-metodologia')"><option value="Scrum">Scrum</option><option value="Kanban">Kanban</option><option value="RUP">RUP</option><option value="Cascada">Cascada / Waterfall</option><option value="Espiral">Espiral / Spiral</option><option value="XP">XP</option><option value="Lean">Lean</option><option value="SAFe">SAFe</option><option value="DevOps">DevOps</option><option value="DevSecOps">DevSecOps</option><option value="Trunk-Based Development">Trunk-Based Development</option><option value="GitHub Flow">GitHub Flow</option><option value="GitFlow">GitFlow</option><option value="__OTHER__">Otro / Other...</option></select><small class="var-help" id="vf-metodologia-help"><span class="fw-lang-es">Permite combinar metodología, proceso y estrategia de ramas.</span><span class="fw-lang-en">Allows combining methodology, process and branching strategy.</span></small><input id="vf-metodologia-other" class="var-other-input" type="text" hidden placeholder="Otra metodología o proceso" oninput="syncProjectFromPanel();updateVarsBadge();"><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[METODOLOGÍA]</span><span class="fw-lang-en">[METHODOLOGY]</span></span><span class="var-tag"><span class="fw-lang-es">[BRANCHING STRATEGY]</span><span class="fw-lang-en">[BRANCHING STRATEGY]</span></span></div></div>
     <div class="var-group"><label for="vf-agentes"><span class="fw-lang-es">Agentes IA activos</span><span class="fw-lang-en">Active AI agents</span></label><input id="vf-agentes" type="text" placeholder="" oninput="syncProjectFromPanel();updateVarsBadge();"><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[LISTA DE AGENTES]</span><span class="fw-lang-en">[AGENT LIST]</span></span><span class="var-tag"><span class="fw-lang-es">[AGENTES A CONFIGURAR]</span><span class="fw-lang-en">[AGENTS TO CONFIGURE]</span></span></div></div>
     <div class="var-group"><label for="vf-autonomia"><span class="fw-lang-es">Nivel de autonomía IA</span><span class="fw-lang-en">AI autonomy level</span></label><select id="vf-autonomia" onchange="syncProjectFromPanel();updateVarsBadge();"><option value="">-- seleccionar --</option><option>solo análisis</option><option>análisis + propuesta</option><option>ejecución controlada</option><option>ejecución autónoma</option></select><div class="var-tags"><span class="var-tag"><span class="fw-lang-es">[NIVEL DE AUTONOMÍA]</span><span class="fw-lang-en">[AUTONOMY LEVEL]</span></span><span class="var-tag"><span class="fw-lang-es">[NIVEL]</span><span class="fw-lang-en">[LEVEL]</span></span></div></div>
   </div>
@@ -9903,8 +9911,80 @@ var QUICK_FIELD_VAR_MAP = {
 function syncFieldsToValues(fieldMap, values) {
   Object.keys(fieldMap).forEach(function(eid) {
     var el = document.getElementById(eid);
-    if (el) el.value = values[fieldMap[eid]] || '';
+    if (!el) return;
+    var value = values[fieldMap[eid]] || '';
+    if (!el.multiple) {
+      el.value = value;
+      return;
+    }
+    var selectedValues = value.split(',').map(function(item) { return item.trim(); }).filter(Boolean);
+    var knownValues = Array.from(el.options).map(function(option) { return option.value; });
+    var customValues = selectedValues.filter(function(item) { return knownValues.indexOf(item) < 0; });
+    Array.from(el.options).forEach(function(option) {
+      option.selected = selectedValues.indexOf(option.value) >= 0;
+    });
+    var otherOption = Array.from(el.options).find(function(option) { return option.value === '__OTHER__'; });
+    if (otherOption) otherOption.selected = customValues.length > 0;
+    el.dataset.selectedValues = JSON.stringify(
+      Array.from(el.selectedOptions).map(function(option) { return option.value; })
+    );
+    var otherInputId = el.getAttribute('data-other-input');
+    var otherInput = otherInputId ? document.getElementById(otherInputId) : null;
+    if (otherInput) {
+      otherInput.value = customValues.join(', ');
+      otherInput.hidden = customValues.length === 0;
+    }
   });
+}
+
+function readFieldValue(el) {
+  if (!el.multiple) return el.value;
+  var values = Array.from(el.selectedOptions)
+    .map(function(option) { return option.value; })
+    .filter(function(value) { return value !== '__OTHER__'; });
+  var otherInputId = el.getAttribute('data-other-input');
+  var otherInput = otherInputId ? document.getElementById(otherInputId) : null;
+  if (otherInput && !otherInput.hidden) {
+    otherInput.value.split(',').map(function(item) { return item.trim(); }).filter(Boolean)
+      .forEach(function(item) { values.push(item); });
+  }
+  return values.join(', ');
+}
+
+function syncMultiSelectOther(selectId) {
+  var select = document.getElementById(selectId);
+  if (!select) return;
+  if (selectId === 'vf-compliance') {
+    var previousValues = [];
+    try { previousValues = JSON.parse(select.dataset.selectedValues || '[]'); } catch (e) {}
+    var currentValues = Array.from(select.selectedOptions).map(function(option) { return option.value; });
+    var newlySelected = currentValues.filter(function(value) {
+      return previousValues.indexOf(value) < 0;
+    });
+    var noneOption = Array.from(select.options).find(function(option) {
+      return option.value === 'NINGUNO';
+    });
+    if (noneOption && newlySelected.indexOf('NINGUNO') >= 0) {
+      Array.from(select.options).forEach(function(option) {
+        option.selected = option.value === 'NINGUNO';
+      });
+    } else if (noneOption && newlySelected.length > 0) {
+      noneOption.selected = false;
+    }
+  }
+  select.dataset.selectedValues = JSON.stringify(
+    Array.from(select.selectedOptions).map(function(option) { return option.value; })
+  );
+  var otherInputId = select.getAttribute('data-other-input');
+  var otherInput = otherInputId ? document.getElementById(otherInputId) : null;
+  if (!otherInput) return;
+  var hasOther = Array.from(select.selectedOptions).some(function(option) {
+    return option.value === '__OTHER__';
+  });
+  otherInput.hidden = !hasOther;
+  if (!hasOther) otherInput.value = '';
+  syncProjectFromPanel();
+  updateVarsBadge();
 }
 
 function updateActiveProjectVars(fieldMap) {
@@ -9915,7 +9995,7 @@ function updateActiveProjectVars(fieldMap) {
   if (!p) return null;
   Object.keys(fieldMap).forEach(function(eid) {
     var el = document.getElementById(eid);
-    if (el) p.vars[fieldMap[eid]] = el.value;
+    if (el) p.vars[fieldMap[eid]] = readFieldValue(el);
   });
   saveProjects(list);
   return p.vars;
@@ -10383,12 +10463,6 @@ function updatePlaceholders(lang) {
     tSelect.options[9].text = lang === 'en' ? 'other' : 'otro';
     tSelect.options[9].value = lang === 'en' ? 'other' : 'otro';
   }
-  var mSelect = document.getElementById('vf-metodologia');
-  if (mSelect && mSelect.options.length > 7) {
-    mSelect.options[0].text = lang === 'en' ? '-- select --' : '-- seleccionar --';
-    mSelect.options[7].text = lang === 'en' ? 'other' : 'otro';
-    mSelect.options[7].value = lang === 'en' ? 'other' : 'otro';
-  }
   var aSelect = document.getElementById('vf-autonomia');
   if (aSelect && aSelect.options.length > 4) {
     aSelect.options[0].text = lang === 'en' ? '-- select --' : '-- seleccionar --';
@@ -10410,6 +10484,8 @@ function updatePlaceholders(lang) {
     'vf-componentes': { es: 'Lista de componentes o rutas de archivos', en: 'List of components or file paths' },
     'vf-modulo': { es: 'Nombre del módulo o funcionalidad', en: 'Module or process name' },
     'vf-stack': { es: 'ej: Python + FastAPI + PostgreSQL + Docker', en: 'e.g., Python + FastAPI + PostgreSQL + Docker' },
+    'vf-compliance-other': { es: 'Otro estándar o regulación', en: 'Other standard or regulation' },
+    'vf-metodologia-other': { es: 'Otra metodología o proceso', en: 'Other methodology or process' },
     'vf-agentes': { es: 'ej: Copilot, Claude, Codex', en: 'e.g., Copilot, Claude, Codex' },
     
     'qv-repositorio': { es: 'org/nombre-repo o URL', en: 'org/repo-name or URL' },

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -129,8 +129,22 @@ def test_framework_context_controls_expose_expected_options():
         "PSP",
         "TSP",
         "ISO 29110",
+        "ISO 9001",
+        "ISO 12207",
+        "ISO 25010",
+        "ISO 27001",
+        "ISO 27002",
+        "ISO 27701",
+        "CMMI-DEV",
         "MOPROSOFT",
         "MAAGTICSI",
+        "NIST CSF",
+        "NIST SSDF",
+        "OWASP SAMM",
+        "PCI DSS",
+        "SOC 2",
+        "GDPR",
+        "HIPAA",
         "NINGUNO",
     ):
         assert f'value="{option}"' in BUILD_SOURCE
@@ -141,3 +155,31 @@ def test_framework_context_controls_expose_expected_options():
     assert "Objetivo puntual de salida" in BUILD_SOURCE
     assert "[INDICAR]" in BUILD_SOURCE
     assert "[NIVEL]" in BUILD_SOURCE
+
+
+def test_compliance_and_methodology_support_multiple_and_custom_values():
+    assert 'id="vf-compliance" multiple' in BUILD_SOURCE
+    assert 'id="vf-metodologia" multiple' in BUILD_SOURCE
+    assert 'id="vf-compliance-other"' in BUILD_SOURCE
+    assert 'id="vf-metodologia-other"' in BUILD_SOURCE
+    assert "function readFieldValue" in BUILD_SOURCE
+    assert "function syncMultiSelectOther" in BUILD_SOURCE
+    assert "newlySelected.indexOf('NINGUNO')" in BUILD_SOURCE
+    assert "noneOption.selected = false" in BUILD_SOURCE
+
+    for methodology in (
+        "Scrum",
+        "Kanban",
+        "RUP",
+        "Cascada",
+        "Espiral",
+        "XP",
+        "Lean",
+        "SAFe",
+        "DevOps",
+        "DevSecOps",
+        "Trunk-Based Development",
+        "GitHub Flow",
+        "GitFlow",
+    ):
+        assert f'value="{methodology}"' in BUILD_SOURCE


### PR DESCRIPTION
## Qué cambia

- Amplía el catálogo de compliance con ISO, CMMI-DEV, NIST, OWASP, PCI DSS, SOC 2, GDPR, HIPAA, PSP/TSP, MOPROSOFT y MAAGTICSI.
- Amplía metodología y proceso con Scrum, RUP, XP, SAFe, Lean, DevOps, DevSecOps y estrategias de branching.
- Permite selección múltiple en ambos controles.
- Agrega opción `Otro` con valores personalizados.
- Hace que `NINGUNO` sea una selección exclusiva.
- Conserva compatibilidad con proyectos previamente guardados en `localStorage`.
- Actualiza requisitos, reglas de negocio, changelog, pruebas y el sitio generado.

## Diseño

Los valores siguen persistiendo como cadenas separadas por comas. Esto mantiene compatible el contrato existente de variables y permite que `applyVars()` continúe sustituyendo los tokens sin cambios.

## Impacto de usuario

El usuario puede combinar estándares y metodologías reales sin mezclarlos semánticamente y sin depender de variables adicionales manuales.

## Validación

- `python build.py`
- `python verify_clean.py`
- `python -m pytest -q` — 41 passed
- `node --check` sobre el JavaScript generado
- `git diff --check`